### PR TITLE
Force dark mode in-app

### DIFF
--- a/dirtycow/dirtycowApp.swift
+++ b/dirtycow/dirtycowApp.swift
@@ -12,6 +12,7 @@ struct dirtycowApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .preferredColorScheme(.dark)
         }
     }
 }


### PR DESCRIPTION
When opening the app in light mode you cannot read any of the text in the table because it is the same colour as the background